### PR TITLE
feat: add cdc service with mysql binlog streaming for real-time repli…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We evaluated MariaDB ColumnStore but chose DuckDB for these reasons:
 - **Cost effective** - $20/month droplet vs $500+/month infrastructure
 - **Better for CDC** - In-process writes with zero network latency
 
-ColumnStore makes sense for petabyte-scale (100TB+) distributed analytics. For MySQL replication under 100GB, DuckDB is optimal.
+ColumnStore makes sense for large-scale (100TB+) distributed analytics. For MySQL replication under 100GB, DuckDB is optimal.
 
 ## Why DuckDB over ClickHouse?
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ We evaluated MariaDB ColumnStore but chose DuckDB for these reasons:
 
 ColumnStore makes sense for petabyte-scale (100TB+) distributed analytics. For MySQL replication under 100GB, DuckDB is optimal.
 
+## Why DuckDB over ClickHouse?
+
+We evaluated ClickHouse but chose DuckDB for these reasons:
+
+- **Lower resource requirements** - DuckDB runs on 4GB RAM vs ClickHouse's 32-64GB minimum for production
+- **Stable MySQL replication** - ClickHouse's `MaterializedMySQL` is experimental and not production-ready
+- **No cluster overhead** - ClickHouse requires ZooKeeper/Keeper even for single-node setups
+- **Better JOIN support** - ClickHouse recommends max 3-4 JOINs; DuckDB handles complex queries natively
+- **ACID transactions** - DuckDB provides full ACID; ClickHouse is optimized for append-only workloads
+- **Simple operations** - Single embedded file vs cluster management, monitoring, and tuning
+- **Cost effective** - $20/month droplet vs $300+/month infrastructure
+
+ClickHouse excels at 10B+ rows with 100K+ rows/sec ingestion and dedicated DevOps teams. For MySQL replication under 100GB, DuckDB is optimal.
+
 ## Quick Start
 
 ### Docker (Recommended)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ A high-performance DuckDB server that replicates data from MySQL using **Sequent
 | **Restart Time** | ✅ Instant |
 | **Code Complexity** | ✅ ~800 lines |
 
+## Why DuckDB over MariaDB ColumnStore?
+
+We evaluated MariaDB ColumnStore but chose DuckDB for these reasons:
+
+- **Zero infrastructure** - DuckDB is embedded, no separate server needed
+- **Low resource requirements** - Runs on 4GB RAM vs ColumnStore's 128GB RAM + 64 cores for production
+- **Empty string support** - ColumnStore treats empty strings as NULL, breaking MySQL compatibility
+- **Full SQL support** - ColumnStore doesn't use indexes (uses extent elimination), no ORDER BY in DELETE/UPDATE
+- **Simple deployment** - Single file vs distributed cluster management
+- **Cost effective** - $20/month droplet vs $500+/month infrastructure
+- **Better for CDC** - In-process writes with zero network latency
+
+ColumnStore makes sense for petabyte-scale (100TB+) distributed analytics. For MySQL replication under 100GB, DuckDB is optimal.
+
 ## Quick Start
 
 ### Docker (Recommended)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,9 +16,10 @@
     "validate": "node dist/cli.js validate"
   },
   "dependencies": {
-    "@duckdb/node-api": "^1.4.2-r.1",
     "@chittihq/duckling-shared": "workspace:*",
+    "@duckdb/node-api": "^1.4.2-r.1",
     "@types/ws": "^8.18.1",
+    "@vlasky/zongji": "^0.5.9",
     "commander": "^11.1.0",
     "cors": "^2.8.5",
     "csv-stringify": "^6.6.0",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -65,6 +65,13 @@ export const config = {
     autoRestart: process.env.AUTO_RESTART !== 'false',
     maxRestartAttempts: parseInt(process.env.MAX_RESTART_ATTEMPTS || '3'),
   },
+
+  cdc: {
+    enabled: process.env.CDC_ENABLED === 'true', // Disabled by default, opt-in
+    autoStart: process.env.CDC_AUTO_START === 'true', // Auto-start on server boot
+    reconnectAttempts: parseInt(process.env.CDC_RECONNECT_ATTEMPTS || '10'),
+    reconnectDelayMs: parseInt(process.env.CDC_RECONNECT_DELAY_MS || '5000'),
+  },
   
   monitoring: {
     enableHealthChecks: process.env.ENABLE_HEALTH_CHECKS !== 'false',

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -71,6 +71,7 @@ export const config = {
     autoStart: process.env.CDC_AUTO_START === 'true', // Auto-start on server boot
     reconnectAttempts: parseInt(process.env.CDC_RECONNECT_ATTEMPTS || '10'),
     reconnectDelayMs: parseInt(process.env.CDC_RECONNECT_DELAY_MS || '5000'),
+    sslRejectUnauthorized: process.env.CDC_SSL_REJECT_UNAUTHORIZED !== 'false', // true by default for security
   },
   
   monitoring: {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,6 +3,7 @@ import logger from './logger';
 import config from './config';
 import * as fs from 'fs';
 import * as path from 'path';
+import { CDCService } from './services/cdcService';
 
 // Enable garbage collection if available
 if (global.gc) {
@@ -90,11 +91,13 @@ async function main() {
 
     process.on('SIGINT', () => {
       console.log('Received SIGINT, shutting down gracefully');
+      CDCService.stopAll();
       process.exit(0);
     });
 
     process.on('SIGTERM', () => {
       console.log('Received SIGTERM, shutting down gracefully');
+      CDCService.stopAll();
       process.exit(0);
     });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -44,6 +44,40 @@ process.on('unhandledRejection', (reason, promise) => {
   process.exit(1);
 });
 
+// Track if shutdown is in progress to prevent duplicate handling
+let isShuttingDown = false;
+
+/**
+ * Graceful shutdown handler - stops CDC pipeline, closes HTTP server
+ */
+async function gracefulShutdown(signal: string, server: DuckDBServer): Promise<void> {
+  if (isShuttingDown) {
+    console.log('Shutdown already in progress...');
+    return;
+  }
+  isShuttingDown = true;
+
+  console.log(`Received ${signal}, starting graceful shutdown...`);
+
+  try {
+    // Stop all CDC instances first (waits for event queues to drain)
+    console.log('Stopping CDC services...');
+    await CDCService.stopAll();
+    console.log('CDC services stopped');
+
+    // Close HTTP server
+    console.log('Closing HTTP server...');
+    await server.stop();
+    console.log('HTTP server closed');
+
+    console.log('Graceful shutdown complete');
+    process.exit(0);
+  } catch (error) {
+    console.error('Error during graceful shutdown:', error);
+    process.exit(1);
+  }
+}
+
 async function main() {
   try {
     console.log('Starting DuckDB Parquet Server...');
@@ -89,17 +123,9 @@ async function main() {
     // Note: Initial sync is handled by the automation service
     // See automationService.ts startPeriodicSync() for automatic sync configuration
 
-    process.on('SIGINT', () => {
-      console.log('Received SIGINT, shutting down gracefully');
-      CDCService.stopAll();
-      process.exit(0);
-    });
-
-    process.on('SIGTERM', () => {
-      console.log('Received SIGTERM, shutting down gracefully');
-      CDCService.stopAll();
-      process.exit(0);
-    });
+    // Register graceful shutdown handlers
+    process.on('SIGINT', () => gracefulShutdown('SIGINT', server));
+    process.on('SIGTERM', () => gracefulShutdown('SIGTERM', server));
 
     console.log('DuckDB Server started successfully and is ready to accept connections');
     console.log('🚀 New Features Available:');

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -6,6 +6,7 @@ import DuckDBConnection from './database/duckdb';
 import MySQLConnection from './database/mysql';
 import SequentialAppenderService from './services/sequentialAppenderService';
 import AutomationService from './services/automationService';
+import CDCService from './services/cdcService';
 import WebSocketService from './services/websocketService';
 import LogBufferService from './services/logBufferService';
 import { DatabaseConfigManager } from './database/databaseConfig';
@@ -176,6 +177,12 @@ class DuckDBServer {
     this.app.post('/automation/backup', attachDatabaseContext, this.manualBackup.bind(this));
     this.app.post('/automation/restore', attachDatabaseContext, this.restoreFromBackup.bind(this));
     this.app.post('/automation/cleanup', attachDatabaseContext, this.manualCleanup.bind(this));
+
+    // CDC (Change Data Capture) endpoints (with database context)
+    this.app.get('/cdc/status', attachDatabaseContext, this.getCDCStatus.bind(this));
+    this.app.post('/cdc/start', attachDatabaseContext, this.startCDC.bind(this));
+    this.app.post('/cdc/stop', attachDatabaseContext, this.stopCDC.bind(this));
+    this.app.post('/cdc/reset-stats', attachDatabaseContext, this.resetCDCStats.bind(this));
 
     // Data access endpoints (with database context)
     this.app.post('/api/query', attachDatabaseContext, this.executeQuery.bind(this));
@@ -828,6 +835,141 @@ class DuckDBServer {
       });
     } catch (error) {
       logger.error('Manual cleanup failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  }
+
+  // CDC (Change Data Capture) endpoint handlers
+  private async getCDCStatus(req: express.Request, res: express.Response): Promise<void> {
+    try {
+      const { databaseId } = req as RequestWithDatabase;
+      const cdcService = CDCService.getInstance(databaseId);
+
+      if (!cdcService) {
+        res.json({
+          success: true,
+          status: {
+            isRunning: false,
+            message: 'CDC service not initialized for this database'
+          },
+          enabled: config.cdc.enabled
+        });
+        return;
+      }
+
+      const stats = cdcService.getStats();
+      res.json({
+        success: true,
+        status: stats,
+        enabled: config.cdc.enabled
+      });
+    } catch (error) {
+      logger.error('Get CDC status failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  }
+
+  private async startCDC(req: express.Request, res: express.Response): Promise<void> {
+    try {
+      const { databaseId } = req as RequestWithDatabase;
+      const dbConfig = DatabaseConfigManager.getInstance().getDatabase(databaseId);
+
+      if (!dbConfig) {
+        res.status(404).json({
+          success: false,
+          error: `Database '${databaseId}' not found`
+        });
+        return;
+      }
+
+      if (!dbConfig.mysqlConnectionString) {
+        res.status(400).json({
+          success: false,
+          error: 'MySQL connection string not configured for this database'
+        });
+        return;
+      }
+
+      // Parse connection string and create CDC config
+      const cdcConfig = CDCService.parseConnectionString(dbConfig.mysqlConnectionString, databaseId);
+
+      // Add exclude tables from sync config
+      cdcConfig.excludeTables = config.sync.excludedTables;
+
+      // Create and start CDC service
+      const cdcService = CDCService.createInstance(cdcConfig);
+      await cdcService.start();
+
+      res.json({
+        success: true,
+        message: `CDC service started for database '${databaseId}'`,
+        status: cdcService.getStats()
+      });
+    } catch (error) {
+      logger.error('Start CDC failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  }
+
+  private async stopCDC(req: express.Request, res: express.Response): Promise<void> {
+    try {
+      const { databaseId } = req as RequestWithDatabase;
+      const cdcService = CDCService.getInstance(databaseId);
+
+      if (!cdcService) {
+        res.status(404).json({
+          success: false,
+          error: `CDC service not running for database '${databaseId}'`
+        });
+        return;
+      }
+
+      cdcService.stop();
+
+      res.json({
+        success: true,
+        message: `CDC service stopped for database '${databaseId}'`
+      });
+    } catch (error) {
+      logger.error('Stop CDC failed:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  }
+
+  private async resetCDCStats(req: express.Request, res: express.Response): Promise<void> {
+    try {
+      const { databaseId } = req as RequestWithDatabase;
+      const cdcService = CDCService.getInstance(databaseId);
+
+      if (!cdcService) {
+        res.status(404).json({
+          success: false,
+          error: `CDC service not running for database '${databaseId}'`
+        });
+        return;
+      }
+
+      cdcService.resetStats();
+
+      res.json({
+        success: true,
+        message: `CDC stats reset for database '${databaseId}'`,
+        status: cdcService.getStats()
+      });
+    } catch (error) {
+      logger.error('Reset CDC stats failed:', error);
       res.status(500).json({
         success: false,
         error: error instanceof Error ? error.message : 'Unknown error'

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -903,7 +903,7 @@ class DuckDBServer {
       cdcConfig.excludeTables = config.sync.excludedTables;
 
       // Create and start CDC service
-      const cdcService = CDCService.createInstance(cdcConfig);
+      const cdcService = await CDCService.createInstance(cdcConfig);
       await cdcService.start();
 
       res.json({
@@ -933,7 +933,7 @@ class DuckDBServer {
         return;
       }
 
-      cdcService.stop();
+      await cdcService.stop();
 
       res.json({
         success: true,
@@ -1606,6 +1606,35 @@ class DuckDBServer {
         message: error instanceof Error ? error.message : 'Unknown error'
       });
     }
+  }
+
+  /**
+   * Stop the HTTP server gracefully
+   */
+  async stop(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+
+      // Stop accepting new connections and wait for existing to close
+      this.server.close((err) => {
+        if (err) {
+          logger.error('Error closing HTTP server:', err);
+          reject(err);
+        } else {
+          logger.info('HTTP server closed successfully');
+          resolve();
+        }
+      });
+
+      // Force close after 10 seconds
+      setTimeout(() => {
+        logger.warn('Forcing HTTP server close after timeout');
+        resolve();
+      }, 10000);
+    });
   }
 
 }

--- a/packages/server/src/services/cdcService.ts
+++ b/packages/server/src/services/cdcService.ts
@@ -16,6 +16,7 @@ import ZongJi from '@vlasky/zongji';
 import logger from '../logger';
 import DuckDBConnection from '../database/duckdb';
 import { DatabaseConfigManager } from '../database/databaseConfig';
+import config from '../config';
 
 interface BinlogPosition {
   filename: string;
@@ -54,11 +55,17 @@ export class CDCService {
   private zongji: ZongJi | null = null;
   private duckdb: DuckDBConnection;
   private isRunning: boolean = false;
+  private isStopped: boolean = false; // Flag to prevent reconnect after explicit stop
   private reconnectAttempts: number = 0;
   private maxReconnectAttempts: number = 10;
   private reconnectDelay: number = 5000;
+  private reconnectTimeoutId: NodeJS.Timeout | null = null; // Track pending reconnect
   private stats: CDCStats;
   private tableSchemas: Map<string, Map<string, string>> = new Map(); // tableName -> columnName -> type
+
+  // Event queue for serialized processing (EventEmitter doesn't await async handlers)
+  private eventQueue: Array<() => Promise<void>> = [];
+  private isProcessingQueue: boolean = false;
 
   constructor(config: CDCConfig) {
     this.databaseId = config.databaseId;
@@ -109,15 +116,31 @@ export class CDCService {
    * Parse MySQL connection string to extract CDC config
    */
   static parseConnectionString(connectionString: string, databaseId: string): CDCConfig {
-    const url = new URL(connectionString);
-    return {
-      databaseId,
-      mysqlHost: url.hostname,
-      mysqlPort: parseInt(url.port) || 3306,
-      mysqlUser: url.username,
-      mysqlPassword: url.password,
-      mysqlDatabase: url.pathname.replace('/', '').split('?')[0]
-    };
+    try {
+      const url = new URL(connectionString);
+
+      // Validate required components
+      if (!url.hostname) {
+        throw new Error('Missing hostname');
+      }
+      if (!url.username) {
+        throw new Error('Missing username');
+      }
+      if (!url.pathname || url.pathname === '/') {
+        throw new Error('Missing database name');
+      }
+
+      return {
+        databaseId,
+        mysqlHost: url.hostname,
+        mysqlPort: parseInt(url.port) || 3306,
+        mysqlUser: url.username,
+        mysqlPassword: url.password,
+        mysqlDatabase: url.pathname.replace('/', '').split('?')[0]
+      };
+    } catch (error) {
+      throw new Error(`Invalid MySQL connection string format: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
   }
 
   /**
@@ -207,6 +230,35 @@ export class CDCService {
   }
 
   /**
+   * Quote SQL identifier to prevent syntax errors with reserved words/special chars
+   */
+  private quoteIdentifier(name: string): string {
+    return `"${name.replace(/"/g, '""')}"`;
+  }
+
+  /**
+   * Process event queue serially to ensure correct ordering
+   */
+  private async processEventQueue(): Promise<void> {
+    if (this.isProcessingQueue) return;
+    this.isProcessingQueue = true;
+
+    while (this.eventQueue.length > 0) {
+      const task = this.eventQueue.shift();
+      if (task) {
+        try {
+          await task();
+        } catch (error) {
+          this.stats.errors++;
+          logger.error(`CDC event processing error:`, error);
+        }
+      }
+    }
+
+    this.isProcessingQueue = false;
+  }
+
+  /**
    * Check if table should be processed
    */
   private shouldProcessTable(tableName: string): boolean {
@@ -243,17 +295,27 @@ export class CDCService {
     }
 
     try {
-      for (const row of rows) {
-        const columns = Object.keys(row);
-        const values = columns.map(col => this.sanitizeValue(row[col]));
-        const placeholders = columns.map(() => '?').join(', ');
+      // Use transaction for atomicity
+      await this.duckdb.run('BEGIN TRANSACTION');
 
-        const query = `INSERT INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
-        await this.duckdb.run(query, values);
+      try {
+        for (const row of rows) {
+          const columns = Object.keys(row);
+          const quotedColumns = columns.map(col => this.quoteIdentifier(col)).join(', ');
+          const values = columns.map(col => this.sanitizeValue(row[col]));
+          const placeholders = columns.map(() => '?').join(', ');
+
+          const query = `INSERT INTO ${this.quoteIdentifier(tableName)} (${quotedColumns}) VALUES (${placeholders})`;
+          await this.duckdb.run(query, values);
+        }
+
+        await this.duckdb.run('COMMIT');
+        this.stats.insertsProcessed += rows.length;
+        logger.debug(`CDC INSERT: ${tableName} - ${rows.length} rows`);
+      } catch (error) {
+        await this.duckdb.run('ROLLBACK');
+        throw error;
       }
-
-      this.stats.insertsProcessed += rows.length;
-      logger.debug(`CDC INSERT: ${tableName} - ${rows.length} rows`);
     } catch (error) {
       this.stats.errors++;
       logger.error(`CDC INSERT failed for ${tableName}:`, error);
@@ -275,20 +337,30 @@ export class CDCService {
     }
 
     try {
-      for (const row of rows) {
-        // row.after contains the new values
-        const afterRow = row.after || row;
-        const columns = Object.keys(afterRow);
-        const values = columns.map(col => this.sanitizeValue(afterRow[col]));
-        const placeholders = columns.map(() => '?').join(', ');
+      // Use transaction for atomicity
+      await this.duckdb.run('BEGIN TRANSACTION');
 
-        // Use INSERT OR REPLACE for upsert behavior
-        const query = `INSERT OR REPLACE INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
-        await this.duckdb.run(query, values);
+      try {
+        for (const row of rows) {
+          // row.after contains the new values
+          const afterRow = row.after || row;
+          const columns = Object.keys(afterRow);
+          const quotedColumns = columns.map(col => this.quoteIdentifier(col)).join(', ');
+          const values = columns.map(col => this.sanitizeValue(afterRow[col]));
+          const placeholders = columns.map(() => '?').join(', ');
+
+          // Use INSERT OR REPLACE for upsert behavior
+          const query = `INSERT OR REPLACE INTO ${this.quoteIdentifier(tableName)} (${quotedColumns}) VALUES (${placeholders})`;
+          await this.duckdb.run(query, values);
+        }
+
+        await this.duckdb.run('COMMIT');
+        this.stats.updatesProcessed += rows.length;
+        logger.debug(`CDC UPDATE: ${tableName} - ${rows.length} rows`);
+      } catch (error) {
+        await this.duckdb.run('ROLLBACK');
+        throw error;
       }
-
-      this.stats.updatesProcessed += rows.length;
-      logger.debug(`CDC UPDATE: ${tableName} - ${rows.length} rows`);
     } catch (error) {
       this.stats.errors++;
       logger.error(`CDC UPDATE failed for ${tableName}:`, error);
@@ -304,26 +376,35 @@ export class CDCService {
     await this.cacheTableSchema(tableName);
 
     try {
-      for (const row of rows) {
-        // Try to find primary key column
-        const pkColumn = this.findPrimaryKeyColumn(tableName, row);
+      // Use transaction for atomicity
+      await this.duckdb.run('BEGIN TRANSACTION');
 
-        if (pkColumn && row[pkColumn] !== undefined) {
-          const query = `DELETE FROM ${tableName} WHERE ${pkColumn} = ?`;
-          await this.duckdb.run(query, [row[pkColumn]]);
-        } else {
-          // Fallback: delete by all columns (exact match)
-          const columns = Object.keys(row);
-          const conditions = columns.map(col => `${col} = ?`).join(' AND ');
-          const values = columns.map(col => this.sanitizeValue(row[col]));
+      try {
+        for (const row of rows) {
+          // Try to find primary key column
+          const pkColumn = this.findPrimaryKeyColumn(tableName, row);
 
-          const query = `DELETE FROM ${tableName} WHERE ${conditions}`;
-          await this.duckdb.run(query, values);
+          if (pkColumn && row[pkColumn] !== undefined) {
+            const query = `DELETE FROM ${this.quoteIdentifier(tableName)} WHERE ${this.quoteIdentifier(pkColumn)} = ?`;
+            await this.duckdb.run(query, [row[pkColumn]]);
+          } else {
+            // Fallback: delete by all columns (exact match)
+            const columns = Object.keys(row);
+            const conditions = columns.map(col => `${this.quoteIdentifier(col)} = ?`).join(' AND ');
+            const values = columns.map(col => this.sanitizeValue(row[col]));
+
+            const query = `DELETE FROM ${this.quoteIdentifier(tableName)} WHERE ${conditions}`;
+            await this.duckdb.run(query, values);
+          }
         }
-      }
 
-      this.stats.deletesProcessed += rows.length;
-      logger.debug(`CDC DELETE: ${tableName} - ${rows.length} rows`);
+        await this.duckdb.run('COMMIT');
+        this.stats.deletesProcessed += rows.length;
+        logger.debug(`CDC DELETE: ${tableName} - ${rows.length} rows`);
+      } catch (error) {
+        await this.duckdb.run('ROLLBACK');
+        throw error;
+      }
     } catch (error) {
       this.stats.errors++;
       logger.error(`CDC DELETE failed for ${tableName}:`, error);
@@ -396,6 +477,7 @@ export class CDCService {
       return;
     }
 
+    this.isStopped = false; // Reset stopped flag
     logger.info(`Starting CDC service for ${this.databaseId}...`);
 
     try {
@@ -412,8 +494,9 @@ export class CDCService {
         user: this.config.mysqlUser,
         password: this.config.mysqlPassword,
         // SSL for DigitalOcean managed MySQL
+        // rejectUnauthorized defaults to true for security, set CDC_SSL_REJECT_UNAUTHORIZED=false for self-signed certs
         ssl: {
-          rejectUnauthorized: false
+          rejectUnauthorized: config.cdc.sslRejectUnauthorized
         }
       });
 
@@ -464,9 +547,10 @@ export class CDCService {
       logger.info(`CDC connected to MySQL binlog for ${this.databaseId}`);
     });
 
-    // Binlog event
-    this.zongji.on('binlog', async (event: any) => {
-      try {
+    // Binlog event - queue events for serial processing to ensure correct ordering
+    this.zongji.on('binlog', (event: any) => {
+      // Push event processing to queue
+      this.eventQueue.push(async () => {
         this.stats.eventsProcessed++;
         this.stats.lastEventAt = new Date();
 
@@ -504,10 +588,10 @@ export class CDCService {
               break;
           }
         }
-      } catch (error) {
-        this.stats.errors++;
-        logger.error(`CDC event processing error for ${this.databaseId}:`, error);
-      }
+      });
+
+      // Process queue (will be no-op if already processing)
+      this.processEventQueue();
     });
 
     // Error event
@@ -529,6 +613,11 @@ export class CDCService {
    * Schedule reconnection attempt
    */
   private scheduleReconnect(): void {
+    if (this.isStopped) {
+      logger.debug(`CDC reconnect skipped - service was explicitly stopped for ${this.databaseId}`);
+      return;
+    }
+
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       logger.error(`CDC max reconnect attempts reached for ${this.databaseId}`);
       return;
@@ -539,7 +628,13 @@ export class CDCService {
 
     logger.info(`CDC reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
 
-    setTimeout(async () => {
+    this.reconnectTimeoutId = setTimeout(async () => {
+      // Check if stopped before attempting reconnect
+      if (this.isStopped) {
+        logger.debug(`CDC reconnect cancelled - service was stopped for ${this.databaseId}`);
+        return;
+      }
+
       try {
         this.stop();
         await this.start();
@@ -554,6 +649,14 @@ export class CDCService {
    * Stop CDC streaming
    */
   stop(): void {
+    this.isStopped = true; // Mark as explicitly stopped
+
+    // Clear any pending reconnect timeout
+    if (this.reconnectTimeoutId) {
+      clearTimeout(this.reconnectTimeoutId);
+      this.reconnectTimeoutId = null;
+    }
+
     if (this.zongji) {
       try {
         this.zongji.stop();

--- a/packages/server/src/services/cdcService.ts
+++ b/packages/server/src/services/cdcService.ts
@@ -1,0 +1,618 @@
+/**
+ * CDC (Change Data Capture) Service
+ *
+ * Real-time MySQL to DuckDB replication using binlog streaming.
+ * Uses @vlasky/zongji for MySQL binlog parsing.
+ *
+ * Features:
+ * - Real-time INSERT, UPDATE, DELETE replication
+ * - Binlog position tracking for resume capability
+ * - Auto-reconnect on disconnect
+ * - Multi-database support
+ * - Graceful error handling
+ */
+
+import ZongJi from '@vlasky/zongji';
+import logger from '../logger';
+import DuckDBConnection from '../database/duckdb';
+import { DatabaseConfigManager } from '../database/databaseConfig';
+
+interface BinlogPosition {
+  filename: string;
+  position: number;
+  timestamp: Date;
+}
+
+interface CDCConfig {
+  databaseId: string;
+  mysqlHost: string;
+  mysqlPort: number;
+  mysqlUser: string;
+  mysqlPassword: string;
+  mysqlDatabase: string;
+  includeTables?: string[];
+  excludeTables?: string[];
+}
+
+interface CDCStats {
+  isRunning: boolean;
+  connectedAt: Date | null;
+  lastEventAt: Date | null;
+  eventsProcessed: number;
+  insertsProcessed: number;
+  updatesProcessed: number;
+  deletesProcessed: number;
+  errors: number;
+  currentPosition: BinlogPosition | null;
+}
+
+export class CDCService {
+  private static instances: Map<string, CDCService> = new Map();
+
+  private databaseId: string;
+  private config: CDCConfig;
+  private zongji: ZongJi | null = null;
+  private duckdb: DuckDBConnection;
+  private isRunning: boolean = false;
+  private reconnectAttempts: number = 0;
+  private maxReconnectAttempts: number = 10;
+  private reconnectDelay: number = 5000;
+  private stats: CDCStats;
+  private tableSchemas: Map<string, Map<string, string>> = new Map(); // tableName -> columnName -> type
+
+  constructor(config: CDCConfig) {
+    this.databaseId = config.databaseId;
+    this.config = config;
+
+    // Get DuckDB connection for this database
+    const dbConfig = DatabaseConfigManager.getInstance().getDatabase(config.databaseId);
+    if (!dbConfig) {
+      throw new Error(`Database config not found for: ${config.databaseId}`);
+    }
+    this.duckdb = DuckDBConnection.getInstance(config.databaseId, dbConfig.duckdbPath);
+
+    this.stats = {
+      isRunning: false,
+      connectedAt: null,
+      lastEventAt: null,
+      eventsProcessed: 0,
+      insertsProcessed: 0,
+      updatesProcessed: 0,
+      deletesProcessed: 0,
+      errors: 0,
+      currentPosition: null
+    };
+  }
+
+  /**
+   * Get or create CDC service instance for a database
+   */
+  static getInstance(databaseId: string): CDCService | null {
+    return CDCService.instances.get(databaseId) || null;
+  }
+
+  /**
+   * Create and register a new CDC service instance
+   */
+  static createInstance(config: CDCConfig): CDCService {
+    if (CDCService.instances.has(config.databaseId)) {
+      const existing = CDCService.instances.get(config.databaseId)!;
+      existing.stop();
+    }
+
+    const instance = new CDCService(config);
+    CDCService.instances.set(config.databaseId, instance);
+    return instance;
+  }
+
+  /**
+   * Parse MySQL connection string to extract CDC config
+   */
+  static parseConnectionString(connectionString: string, databaseId: string): CDCConfig {
+    const url = new URL(connectionString);
+    return {
+      databaseId,
+      mysqlHost: url.hostname,
+      mysqlPort: parseInt(url.port) || 3306,
+      mysqlUser: url.username,
+      mysqlPassword: url.password,
+      mysqlDatabase: url.pathname.replace('/', '').split('?')[0]
+    };
+  }
+
+  /**
+   * Initialize binlog position tracking table
+   */
+  private async initPositionTable(): Promise<void> {
+    await this.duckdb.run(`
+      CREATE TABLE IF NOT EXISTS cdc_binlog_position (
+        database_id VARCHAR PRIMARY KEY,
+        filename VARCHAR NOT NULL,
+        position BIGINT NOT NULL,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+  }
+
+  /**
+   * Get last saved binlog position
+   */
+  private async getLastPosition(): Promise<BinlogPosition | null> {
+    try {
+      const result = await this.duckdb.execute(
+        'SELECT filename, position, updated_at FROM cdc_binlog_position WHERE database_id = ?',
+        [this.databaseId]
+      );
+
+      if (result.length > 0) {
+        return {
+          filename: result[0].filename,
+          position: Number(result[0].position),
+          timestamp: new Date(result[0].updated_at)
+        };
+      }
+      return null;
+    } catch (error) {
+      logger.warn(`Failed to get last binlog position for ${this.databaseId}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Save current binlog position
+   */
+  private async savePosition(filename: string, position: number): Promise<void> {
+    try {
+      await this.duckdb.run(`
+        INSERT OR REPLACE INTO cdc_binlog_position (database_id, filename, position, updated_at)
+        VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+      `, [this.databaseId, filename, position]);
+
+      this.stats.currentPosition = {
+        filename,
+        position,
+        timestamp: new Date()
+      };
+    } catch (error) {
+      logger.error(`Failed to save binlog position for ${this.databaseId}:`, error);
+    }
+  }
+
+  /**
+   * Cache table schema for column mapping
+   */
+  private async cacheTableSchema(tableName: string): Promise<void> {
+    if (this.tableSchemas.has(tableName)) {
+      return;
+    }
+
+    try {
+      const columns = await this.duckdb.execute(`
+        SELECT column_name, data_type
+        FROM information_schema.columns
+        WHERE table_schema = 'main' AND table_name = ?
+        ORDER BY ordinal_position
+      `, [tableName]);
+
+      const schemaMap = new Map<string, string>();
+      for (const col of columns) {
+        schemaMap.set(col.column_name, col.data_type);
+      }
+      this.tableSchemas.set(tableName, schemaMap);
+
+      logger.debug(`Cached schema for table ${tableName}: ${columns.length} columns`);
+    } catch (error) {
+      logger.warn(`Failed to cache schema for ${tableName}:`, error);
+    }
+  }
+
+  /**
+   * Check if table should be processed
+   */
+  private shouldProcessTable(tableName: string): boolean {
+    // Check exclude list
+    if (this.config.excludeTables?.includes(tableName)) {
+      return false;
+    }
+
+    // Check include list (if specified)
+    if (this.config.includeTables && this.config.includeTables.length > 0) {
+      return this.config.includeTables.includes(tableName);
+    }
+
+    // Skip internal tables
+    if (['cdc_binlog_position', 'appender_watermarks', 'sync_log'].includes(tableName)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Handle INSERT event
+   */
+  private async handleInsert(tableName: string, rows: any[]): Promise<void> {
+    if (!this.shouldProcessTable(tableName)) return;
+
+    await this.cacheTableSchema(tableName);
+    const schema = this.tableSchemas.get(tableName);
+
+    if (!schema || schema.size === 0) {
+      logger.warn(`No schema found for table ${tableName}, skipping INSERT`);
+      return;
+    }
+
+    try {
+      for (const row of rows) {
+        const columns = Object.keys(row);
+        const values = columns.map(col => this.sanitizeValue(row[col]));
+        const placeholders = columns.map(() => '?').join(', ');
+
+        const query = `INSERT INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
+        await this.duckdb.run(query, values);
+      }
+
+      this.stats.insertsProcessed += rows.length;
+      logger.debug(`CDC INSERT: ${tableName} - ${rows.length} rows`);
+    } catch (error) {
+      this.stats.errors++;
+      logger.error(`CDC INSERT failed for ${tableName}:`, error);
+    }
+  }
+
+  /**
+   * Handle UPDATE event
+   */
+  private async handleUpdate(tableName: string, rows: any[]): Promise<void> {
+    if (!this.shouldProcessTable(tableName)) return;
+
+    await this.cacheTableSchema(tableName);
+    const schema = this.tableSchemas.get(tableName);
+
+    if (!schema || schema.size === 0) {
+      logger.warn(`No schema found for table ${tableName}, skipping UPDATE`);
+      return;
+    }
+
+    try {
+      for (const row of rows) {
+        // row.after contains the new values
+        const afterRow = row.after || row;
+        const columns = Object.keys(afterRow);
+        const values = columns.map(col => this.sanitizeValue(afterRow[col]));
+        const placeholders = columns.map(() => '?').join(', ');
+
+        // Use INSERT OR REPLACE for upsert behavior
+        const query = `INSERT OR REPLACE INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})`;
+        await this.duckdb.run(query, values);
+      }
+
+      this.stats.updatesProcessed += rows.length;
+      logger.debug(`CDC UPDATE: ${tableName} - ${rows.length} rows`);
+    } catch (error) {
+      this.stats.errors++;
+      logger.error(`CDC UPDATE failed for ${tableName}:`, error);
+    }
+  }
+
+  /**
+   * Handle DELETE event
+   */
+  private async handleDelete(tableName: string, rows: any[]): Promise<void> {
+    if (!this.shouldProcessTable(tableName)) return;
+
+    await this.cacheTableSchema(tableName);
+
+    try {
+      for (const row of rows) {
+        // Try to find primary key column
+        const pkColumn = this.findPrimaryKeyColumn(tableName, row);
+
+        if (pkColumn && row[pkColumn] !== undefined) {
+          const query = `DELETE FROM ${tableName} WHERE ${pkColumn} = ?`;
+          await this.duckdb.run(query, [row[pkColumn]]);
+        } else {
+          // Fallback: delete by all columns (exact match)
+          const columns = Object.keys(row);
+          const conditions = columns.map(col => `${col} = ?`).join(' AND ');
+          const values = columns.map(col => this.sanitizeValue(row[col]));
+
+          const query = `DELETE FROM ${tableName} WHERE ${conditions}`;
+          await this.duckdb.run(query, values);
+        }
+      }
+
+      this.stats.deletesProcessed += rows.length;
+      logger.debug(`CDC DELETE: ${tableName} - ${rows.length} rows`);
+    } catch (error) {
+      this.stats.errors++;
+      logger.error(`CDC DELETE failed for ${tableName}:`, error);
+    }
+  }
+
+  /**
+   * Find primary key column for a table
+   */
+  private findPrimaryKeyColumn(tableName: string, row: any): string | null {
+    const columns = Object.keys(row);
+
+    // Common primary key patterns
+    const pkPatterns = [
+      'id',
+      `${tableName.toLowerCase()}id`,
+      `${tableName.toLowerCase()}_id`,
+      tableName.charAt(0).toLowerCase() + tableName.slice(1) + 'Id'
+    ];
+
+    for (const pattern of pkPatterns) {
+      const match = columns.find(col => col.toLowerCase() === pattern.toLowerCase());
+      if (match) return match;
+    }
+
+    // Check for columns ending with 'Id' or '_id'
+    const idColumn = columns.find(col =>
+      col.endsWith('Id') || col.endsWith('_id') || col === 'id'
+    );
+
+    return idColumn || null;
+  }
+
+  /**
+   * Sanitize value for DuckDB insertion
+   */
+  private sanitizeValue(value: any): any {
+    if (value === undefined) return null;
+    if (value === null) return null;
+
+    // Handle Date objects
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+
+    // Handle Buffer (BLOB)
+    if (Buffer.isBuffer(value)) {
+      return value;
+    }
+
+    // Handle BigInt
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+
+    // Handle objects (JSON)
+    if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
+
+    return value;
+  }
+
+  /**
+   * Start CDC streaming
+   */
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      logger.warn(`CDC already running for ${this.databaseId}`);
+      return;
+    }
+
+    logger.info(`Starting CDC service for ${this.databaseId}...`);
+
+    try {
+      // Initialize position tracking
+      await this.initPositionTable();
+
+      // Get last position for resume
+      const lastPosition = await this.getLastPosition();
+
+      // Create zongji instance
+      this.zongji = new ZongJi({
+        host: this.config.mysqlHost,
+        port: this.config.mysqlPort,
+        user: this.config.mysqlUser,
+        password: this.config.mysqlPassword,
+        // SSL for DigitalOcean managed MySQL
+        ssl: {
+          rejectUnauthorized: false
+        }
+      });
+
+      // Set up event handlers
+      this.setupEventHandlers();
+
+      // Start options
+      const startOptions: any = {
+        includeEvents: ['tablemap', 'writerows', 'updaterows', 'deleterows'],
+        includeSchema: {
+          [this.config.mysqlDatabase]: true
+        }
+      };
+
+      // Resume from last position if available
+      if (lastPosition) {
+        startOptions.filename = lastPosition.filename;
+        startOptions.position = lastPosition.position;
+        logger.info(`Resuming CDC from position: ${lastPosition.filename}:${lastPosition.position}`);
+      } else {
+        startOptions.startAtEnd = true;
+        logger.info(`Starting CDC from current binlog position`);
+      }
+
+      // Start streaming
+      this.zongji.start(startOptions);
+
+      this.isRunning = true;
+      this.stats.isRunning = true;
+      this.stats.connectedAt = new Date();
+      this.reconnectAttempts = 0;
+
+      logger.info(`CDC service started for ${this.databaseId}`);
+    } catch (error) {
+      logger.error(`Failed to start CDC for ${this.databaseId}:`, error);
+      this.scheduleReconnect();
+    }
+  }
+
+  /**
+   * Set up zongji event handlers
+   */
+  private setupEventHandlers(): void {
+    if (!this.zongji) return;
+
+    // Ready event
+    this.zongji.on('ready', () => {
+      logger.info(`CDC connected to MySQL binlog for ${this.databaseId}`);
+    });
+
+    // Binlog event
+    this.zongji.on('binlog', async (event: any) => {
+      try {
+        this.stats.eventsProcessed++;
+        this.stats.lastEventAt = new Date();
+
+        const eventName = event.getTypeName();
+
+        // Save position periodically (every 100 events or on important events)
+        if (event.nextPosition && (this.stats.eventsProcessed % 100 === 0 ||
+            ['WriteRows', 'UpdateRows', 'DeleteRows'].includes(eventName))) {
+          await this.savePosition(
+            event.binlogName || 'mysql-bin.000001',
+            event.nextPosition
+          );
+        }
+
+        // Handle row events
+        if (event.tableMap && event.tableMap[event.tableId]) {
+          const tableInfo = event.tableMap[event.tableId];
+          const tableName = tableInfo.tableName;
+          const database = tableInfo.parentSchema;
+
+          // Only process events for our database
+          if (database !== this.config.mysqlDatabase) {
+            return;
+          }
+
+          switch (eventName) {
+            case 'WriteRows':
+              await this.handleInsert(tableName, event.rows);
+              break;
+            case 'UpdateRows':
+              await this.handleUpdate(tableName, event.rows);
+              break;
+            case 'DeleteRows':
+              await this.handleDelete(tableName, event.rows);
+              break;
+          }
+        }
+      } catch (error) {
+        this.stats.errors++;
+        logger.error(`CDC event processing error for ${this.databaseId}:`, error);
+      }
+    });
+
+    // Error event
+    this.zongji.on('error', (error: Error) => {
+      this.stats.errors++;
+      logger.error(`CDC error for ${this.databaseId}:`, error);
+      this.scheduleReconnect();
+    });
+
+    // Stopped event
+    this.zongji.on('stopped', () => {
+      logger.warn(`CDC stopped for ${this.databaseId}`);
+      this.isRunning = false;
+      this.stats.isRunning = false;
+    });
+  }
+
+  /**
+   * Schedule reconnection attempt
+   */
+  private scheduleReconnect(): void {
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+      logger.error(`CDC max reconnect attempts reached for ${this.databaseId}`);
+      return;
+    }
+
+    this.reconnectAttempts++;
+    const delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1); // Exponential backoff
+
+    logger.info(`CDC reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
+
+    setTimeout(async () => {
+      try {
+        this.stop();
+        await this.start();
+      } catch (error) {
+        logger.error(`CDC reconnect failed for ${this.databaseId}:`, error);
+        this.scheduleReconnect();
+      }
+    }, delay);
+  }
+
+  /**
+   * Stop CDC streaming
+   */
+  stop(): void {
+    if (this.zongji) {
+      try {
+        this.zongji.stop();
+      } catch (error) {
+        logger.warn(`Error stopping zongji for ${this.databaseId}:`, error);
+      }
+      this.zongji = null;
+    }
+
+    this.isRunning = false;
+    this.stats.isRunning = false;
+    logger.info(`CDC service stopped for ${this.databaseId}`);
+  }
+
+  /**
+   * Get CDC statistics
+   */
+  getStats(): CDCStats {
+    return { ...this.stats };
+  }
+
+  /**
+   * Check if CDC is running
+   */
+  isActive(): boolean {
+    return this.isRunning;
+  }
+
+  /**
+   * Reset statistics
+   */
+  resetStats(): void {
+    this.stats = {
+      ...this.stats,
+      eventsProcessed: 0,
+      insertsProcessed: 0,
+      updatesProcessed: 0,
+      deletesProcessed: 0,
+      errors: 0
+    };
+  }
+
+  /**
+   * Stop all CDC instances
+   */
+  static stopAll(): void {
+    for (const [databaseId, instance] of CDCService.instances) {
+      logger.info(`Stopping CDC for ${databaseId}`);
+      instance.stop();
+    }
+    CDCService.instances.clear();
+  }
+
+  /**
+   * Get all CDC instances
+   */
+  static getAllInstances(): Map<string, CDCService> {
+    return CDCService.instances;
+  }
+}
+
+export default CDCService;

--- a/packages/server/src/services/cdcService.ts
+++ b/packages/server/src/services/cdcService.ts
@@ -66,6 +66,8 @@ export class CDCService {
   // Event queue for serialized processing (EventEmitter doesn't await async handlers)
   private eventQueue: Array<() => Promise<void>> = [];
   private isProcessingQueue: boolean = false;
+  private queueDrainPromise: Promise<void> | null = null;
+  private queueDrainResolve: (() => void) | null = null;
 
   constructor(config: CDCConfig) {
     this.databaseId = config.databaseId;
@@ -101,10 +103,10 @@ export class CDCService {
   /**
    * Create and register a new CDC service instance
    */
-  static createInstance(config: CDCConfig): CDCService {
+  static async createInstance(config: CDCConfig): Promise<CDCService> {
     if (CDCService.instances.has(config.databaseId)) {
       const existing = CDCService.instances.get(config.databaseId)!;
-      existing.stop();
+      await existing.stop();
     }
 
     const instance = new CDCService(config);
@@ -256,6 +258,35 @@ export class CDCService {
     }
 
     this.isProcessingQueue = false;
+
+    // Resolve drain promise if someone is waiting
+    if (this.queueDrainResolve) {
+      this.queueDrainResolve();
+      this.queueDrainResolve = null;
+      this.queueDrainPromise = null;
+    }
+  }
+
+  /**
+   * Wait for the event queue to drain completely
+   */
+  private async waitForQueueDrain(): Promise<void> {
+    // If queue is empty and not processing, resolve immediately
+    if (this.eventQueue.length === 0 && !this.isProcessingQueue) {
+      return;
+    }
+
+    // If already have a drain promise, reuse it
+    if (this.queueDrainPromise) {
+      return this.queueDrainPromise;
+    }
+
+    // Create a new drain promise
+    this.queueDrainPromise = new Promise<void>((resolve) => {
+      this.queueDrainResolve = resolve;
+    });
+
+    return this.queueDrainPromise;
   }
 
   /**
@@ -636,7 +667,7 @@ export class CDCService {
       }
 
       try {
-        this.stop();
+        await this.stop();
         await this.start();
       } catch (error) {
         logger.error(`CDC reconnect failed for ${this.databaseId}:`, error);
@@ -646,9 +677,9 @@ export class CDCService {
   }
 
   /**
-   * Stop CDC streaming
+   * Stop CDC streaming gracefully, waiting for queue to drain
    */
-  stop(): void {
+  async stop(): Promise<void> {
     this.isStopped = true; // Mark as explicitly stopped
 
     // Clear any pending reconnect timeout
@@ -657,6 +688,7 @@ export class CDCService {
       this.reconnectTimeoutId = null;
     }
 
+    // Stop zongji first to prevent new events
     if (this.zongji) {
       try {
         this.zongji.stop();
@@ -664,6 +696,13 @@ export class CDCService {
         logger.warn(`Error stopping zongji for ${this.databaseId}:`, error);
       }
       this.zongji = null;
+    }
+
+    // Wait for pending events in queue to finish processing
+    if (this.eventQueue.length > 0 || this.isProcessingQueue) {
+      logger.info(`CDC waiting for ${this.eventQueue.length} pending events to drain for ${this.databaseId}...`);
+      await this.waitForQueueDrain();
+      logger.info(`CDC queue drained for ${this.databaseId}`);
     }
 
     this.isRunning = false;
@@ -700,13 +739,18 @@ export class CDCService {
   }
 
   /**
-   * Stop all CDC instances
+   * Stop all CDC instances gracefully, waiting for all queues to drain
    */
-  static stopAll(): void {
+  static async stopAll(): Promise<void> {
+    const stopPromises: Promise<void>[] = [];
+
     for (const [databaseId, instance] of CDCService.instances) {
       logger.info(`Stopping CDC for ${databaseId}`);
-      instance.stop();
+      stopPromises.push(instance.stop());
     }
+
+    // Wait for all instances to stop
+    await Promise.all(stopPromises);
     CDCService.instances.clear();
   }
 

--- a/packages/server/src/types/zongji.d.ts
+++ b/packages/server/src/types/zongji.d.ts
@@ -1,0 +1,101 @@
+/**
+ * Type definitions for @vlasky/zongji
+ * MySQL binlog parser for Node.js
+ */
+
+declare module '@vlasky/zongji' {
+  import { EventEmitter } from 'events';
+
+  interface ZongJiOptions {
+    host?: string;
+    port?: number;
+    user?: string;
+    password?: string;
+    database?: string;
+    ssl?: {
+      rejectUnauthorized?: boolean;
+      ca?: string | Buffer;
+      cert?: string | Buffer;
+      key?: string | Buffer;
+    };
+    // Existing MySQL connection or pool
+    connection?: any;
+  }
+
+  interface StartOptions {
+    /** Unique server ID (1 to 2^32-1), must be unique among replication slaves */
+    serverId?: number;
+    /** Start from end of binlog (only new events) */
+    startAtEnd?: boolean;
+    /** Start from specific binlog file */
+    filename?: string;
+    /** Start from specific position in binlog file */
+    position?: number;
+    /** Event types to include */
+    includeEvents?: string[];
+    /** Event types to exclude */
+    excludeEvents?: string[];
+    /** Databases/tables to include: { dbName: true } or { dbName: ['table1', 'table2'] } */
+    includeSchema?: { [key: string]: boolean | string[] };
+    /** Databases/tables to exclude */
+    excludeSchema?: { [key: string]: boolean | string[] };
+  }
+
+  interface BinlogEvent {
+    /** Get event type name */
+    getTypeName(): string;
+    /** Get event name */
+    getEventName(): string;
+    /** Dump event to console */
+    dump(): void;
+    /** Binlog filename */
+    binlogName?: string;
+    /** Next position in binlog */
+    nextPosition?: number;
+    /** Table ID for row events */
+    tableId?: number;
+    /** Table map with schema info */
+    tableMap?: {
+      [tableId: number]: {
+        tableName: string;
+        parentSchema: string;
+        columns: Array<{
+          name: string;
+          type: string;
+          charset?: string;
+          nullable: boolean;
+        }>;
+      };
+    };
+    /** Rows for WriteRows, UpdateRows, DeleteRows events */
+    rows?: any[];
+    /** SQL statement for Query events */
+    query?: string;
+    /** Timestamp */
+    timestamp?: number;
+  }
+
+  class ZongJi extends EventEmitter {
+    constructor(options: ZongJiOptions);
+
+    /** Start receiving binlog events */
+    start(options?: StartOptions): void;
+
+    /** Stop receiving binlog events */
+    stop(): void;
+
+    /** Event: Connection ready */
+    on(event: 'ready', listener: () => void): this;
+
+    /** Event: Binlog event received */
+    on(event: 'binlog', listener: (event: BinlogEvent) => void): this;
+
+    /** Event: Error occurred */
+    on(event: 'error', listener: (error: Error) => void): this;
+
+    /** Event: Connection stopped */
+    on(event: 'stopped', listener: () => void): this;
+  }
+
+  export = ZongJi;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: link:../shared
       '@vueuse/core':
         specifier: ^14.0.0
-        version: 14.0.0(vue@3.5.26(typescript@5.8.3))
+        version: 14.0.0(vue@3.5.27(typescript@5.8.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -34,19 +34,19 @@ importers:
         version: 2.1.1
       lucide-vue-next:
         specifier: ^0.552.0
-        version: 0.552.0(vue@3.5.26(typescript@5.8.3))
+        version: 0.552.0(vue@3.5.27(typescript@5.8.3))
       nuxt:
         specifier: ^3.15.1
-        version: 3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.26)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+        version: 3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.27)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       reka-ui:
         specifier: ^2.6.0
-        version: 2.6.0(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3))
+        version: 2.6.0(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3))
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
       vue:
         specifier: latest
-        version: 3.5.26(typescript@5.8.3)
+        version: 3.5.27(typescript@5.8.3)
     devDependencies:
       '@nuxtjs/tailwindcss':
         specifier: ^6.14.0
@@ -96,7 +96,7 @@ importers:
         version: 5.8.3
       unbuild:
         specifier: ^3.6.1
-        version: 3.6.1(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3))
+        version: 3.6.1(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3))
 
   packages/server:
     dependencies:
@@ -109,6 +109,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      '@vlasky/zongji':
+        specifier: ^0.5.9
+        version: 0.5.9
       commander:
         specifier: ^11.1.0
         version: 11.1.0
@@ -1540,6 +1543,14 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.2.25
 
+  '@vlasky/mysql@2.18.7':
+    resolution: {integrity: sha512-enkl4DCEFss5n7Gpe2ZTWvE85edQyYzdW3hAv0Kegx6MLmz6s7xHEqk4iG430RjDxINnCf4QPJMProccBRq39w==}
+    engines: {node: '>= 0.6'}
+
+  '@vlasky/zongji@0.5.9':
+    resolution: {integrity: sha512-B4pz9a8QJw7hOOcfxtuT26PSVcQvGHlZcXG34T5jh/zjJZJ4/7pW7mioW6Cyxfl/mv/7Rcow+hVgfYpCTAjTMw==}
+    engines: {node: '>= 8.0'}
+
   '@volar/language-core@2.4.23':
     resolution: {integrity: sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==}
 
@@ -1574,26 +1585,26 @@ packages:
   '@vue/compiler-core@3.5.24':
     resolution: {integrity: sha512-eDl5H57AOpNakGNAkFDH+y7kTqrQpJkZFXhWZQGyx/5Wh7B1uQYvcWkvZi11BDhscPgj8N7XV3oRwiPnx1Vrig==}
 
-  '@vue/compiler-core@3.5.26':
-    resolution: {integrity: sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==}
+  '@vue/compiler-core@3.5.27':
+    resolution: {integrity: sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==}
 
   '@vue/compiler-dom@3.5.24':
     resolution: {integrity: sha512-1QHGAvs53gXkWdd3ZMGYuvQFXHW4ksKWPG8HP8/2BscrbZ0brw183q2oNWjMrSWImYLHxHrx1ItBQr50I/q2zw==}
 
-  '@vue/compiler-dom@3.5.26':
-    resolution: {integrity: sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==}
+  '@vue/compiler-dom@3.5.27':
+    resolution: {integrity: sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==}
 
   '@vue/compiler-sfc@3.5.24':
     resolution: {integrity: sha512-8EG5YPRgmTB+YxYBM3VXy8zHD9SWHUJLIGPhDovo3Z8VOgvP+O7UP5vl0J4BBPWYD9vxtBabzW1EuEZ+Cqs14g==}
 
-  '@vue/compiler-sfc@3.5.26':
-    resolution: {integrity: sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==}
+  '@vue/compiler-sfc@3.5.27':
+    resolution: {integrity: sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==}
 
   '@vue/compiler-ssr@3.5.24':
     resolution: {integrity: sha512-trOvMWNBMQ/odMRHW7Ae1CdfYx+7MuiQu62Jtu36gMLXcaoqKvAyh+P73sYG9ll+6jLB6QPovqoKGGZROzkFFg==}
 
-  '@vue/compiler-ssr@3.5.26':
-    resolution: {integrity: sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==}
+  '@vue/compiler-ssr@3.5.27':
+    resolution: {integrity: sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -1617,19 +1628,19 @@ packages:
       typescript:
         optional: true
 
-  '@vue/reactivity@3.5.26':
-    resolution: {integrity: sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==}
+  '@vue/reactivity@3.5.27':
+    resolution: {integrity: sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ==}
 
-  '@vue/runtime-core@3.5.26':
-    resolution: {integrity: sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==}
+  '@vue/runtime-core@3.5.27':
+    resolution: {integrity: sha512-fxVuX/fzgzeMPn/CLQecWeDIFNt3gQVhxM0rW02Tvp/YmZfXQgcTXlakq7IMutuZ/+Ogbn+K0oct9J3JZfyk3A==}
 
-  '@vue/runtime-dom@3.5.26':
-    resolution: {integrity: sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==}
+  '@vue/runtime-dom@3.5.27':
+    resolution: {integrity: sha512-/QnLslQgYqSJ5aUmb5F0z0caZPGHRB8LEAQ1s81vHFM5CBfnun63rxhvE/scVb/j3TbBuoZwkJyiLCkBluMpeg==}
 
-  '@vue/server-renderer@3.5.26':
-    resolution: {integrity: sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==}
+  '@vue/server-renderer@3.5.27':
+    resolution: {integrity: sha512-qOz/5thjeP1vAFc4+BY3Nr6wxyLhpeQgAE/8dDtKo6a6xdk+L4W46HDZgNmLOBUDEkFXV3G7pRiUqxjX0/2zWA==}
     peerDependencies:
-      vue: 3.5.26
+      vue: 3.5.27
 
   '@vue/shared@3.5.22':
     resolution: {integrity: sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==}
@@ -1637,8 +1648,8 @@ packages:
   '@vue/shared@3.5.24':
     resolution: {integrity: sha512-9cwHL2EsJBdi8NY22pngYYWzkTDhld6fAD6jlaeloNGciNSJL6bLpbxVgXl96X00Jtc6YWQv96YA/0sxex/k1A==}
 
-  '@vue/shared@3.5.26':
-    resolution: {integrity: sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==}
+  '@vue/shared@3.5.27':
+    resolution: {integrity: sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==}
 
   '@vueuse/core@12.8.2':
     resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
@@ -1797,6 +1808,13 @@ packages:
   baseline-browser-mapping@2.8.23:
     resolution: {integrity: sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ==}
     hasBin: true
+
+  big-integer@1.6.51:
+    resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
+    engines: {node: '>=0.6'}
+
+  bignumber.js@9.1.1:
+    resolution: {integrity: sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -3713,6 +3731,9 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  readable-stream@2.3.7:
+    resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
+
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -4539,8 +4560,8 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
-  vue@3.5.26:
-    resolution: {integrity: sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==}
+  vue@3.5.27:
+    resolution: {integrity: sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -5063,11 +5084,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@floating-ui/vue@1.1.9(vue@3.5.26(typescript@5.8.3))':
+  '@floating-ui/vue@1.1.9(vue@3.5.27(typescript@5.8.3))':
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@floating-ui/utils': 0.2.10
-      vue-demi: 0.14.10(vue@3.5.26(typescript@5.8.3))
+      vue-demi: 0.14.10(vue@3.5.27(typescript@5.8.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -5229,12 +5250,12 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.3
 
-  '@nuxt/devtools@2.7.0(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.26(typescript@5.8.3))':
+  '@nuxt/devtools@2.7.0(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.27(typescript@5.8.3))':
     dependencies:
       '@nuxt/devtools-kit': 2.7.0(magicast@0.3.5)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@nuxt/devtools-wizard': 2.7.0
       '@nuxt/kit': 3.20.0(magicast@0.3.5)
-      '@vue/devtools-core': 7.7.7(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.26(typescript@5.8.3))
+      '@vue/devtools-core': 7.7.7(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.27(typescript@5.8.3))
       '@vue/devtools-kit': 7.7.7
       birpc: 2.6.1
       consola: 3.4.2
@@ -5261,7 +5282,7 @@ snapshots:
       tinyglobby: 0.2.15
       vite: 7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       vite-plugin-inspect: 11.3.3(@nuxt/kit@3.20.0(magicast@0.5.1))(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
-      vite-plugin-vue-tracer: 1.0.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.26(typescript@5.8.3))
+      vite-plugin-vue-tracer: 1.0.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.27(typescript@5.8.3))
       which: 5.0.0
       ws: 8.18.3
     transitivePeerDependencies:
@@ -5347,11 +5368,11 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@3.20.0(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(nuxt@3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.26)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(typescript@5.8.3)':
+  '@nuxt/nitro-server@3.20.0(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(nuxt@3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.27)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(typescript@5.8.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 3.20.0(magicast@0.5.1)
-      '@unhead/vue': 2.0.19(vue@3.5.26(typescript@5.8.3))
+      '@unhead/vue': 2.0.19(vue@3.5.27(typescript@5.8.3))
       '@vue/shared': 3.5.24
       consola: 3.4.2
       defu: 6.1.4
@@ -5365,7 +5386,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.12.9(encoding@0.1.13)(mysql2@3.14.2)
-      nuxt: 3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.26)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+      nuxt: 3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.27)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       pathe: 2.0.3
       pkg-types: 2.3.0
       radix3: 1.1.2
@@ -5373,7 +5394,7 @@ snapshots:
       ufo: 1.6.1
       unctx: 2.4.1
       unstorage: 1.17.2(db0@0.3.4(mysql2@3.14.2))(ioredis@5.8.2)
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
     transitivePeerDependencies:
@@ -5436,12 +5457,12 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/vite-builder@3.20.0(@types/node@20.19.8)(magicast@0.5.1)(nuxt@3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.26)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3))(yaml@2.8.1)':
+  '@nuxt/vite-builder@3.20.0(@types/node@20.19.8)(magicast@0.5.1)(nuxt@3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.27)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 3.20.0(magicast@0.5.1)
       '@rollup/plugin-replace': 6.0.3(rollup@4.52.5)
-      '@vitejs/plugin-vue': 6.0.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.26(typescript@5.8.3))
-      '@vitejs/plugin-vue-jsx': 5.1.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.26(typescript@5.8.3))
+      '@vitejs/plugin-vue': 6.0.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.27(typescript@5.8.3))
+      '@vitejs/plugin-vue-jsx': 5.1.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.27(typescript@5.8.3))
       autoprefixer: 10.4.21(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.2(postcss@8.5.6)
@@ -5457,7 +5478,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.0
       mocked-exports: 0.1.1
-      nuxt: 3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.26)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
+      nuxt: 3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.27)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 2.0.0
@@ -5471,7 +5492,7 @@ snapshots:
       vite: 7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       vite-node: 3.2.4(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       vite-plugin-checker: 0.11.0(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
       vue-bundle-renderer: 2.2.0
     transitivePeerDependencies:
       - '@biomejs/biome'
@@ -5906,10 +5927,10 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
-  '@tanstack/vue-virtual@3.13.12(vue@3.5.26(typescript@5.8.3))':
+  '@tanstack/vue-virtual@3.13.12(vue@3.5.27(typescript@5.8.3))':
     dependencies:
       '@tanstack/virtual-core': 3.13.12
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -6003,11 +6024,11 @@ snapshots:
     dependencies:
       '@types/node': 20.19.8
 
-  '@unhead/vue@2.0.19(vue@3.5.26(typescript@5.8.3))':
+  '@unhead/vue@2.0.19(vue@3.5.27(typescript@5.8.3))':
     dependencies:
       hookable: 5.5.3
       unhead: 2.0.19
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
 
   '@vercel/nft@0.30.3(encoding@0.1.13)(rollup@4.52.5)':
     dependencies:
@@ -6028,7 +6049,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.26(typescript@5.8.3))':
+  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.27(typescript@5.8.3))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
@@ -6036,15 +6057,28 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.45
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.5)
       vite: 7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.26(typescript@5.8.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.27(typescript@5.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
+
+  '@vlasky/mysql@2.18.7':
+    dependencies:
+      bignumber.js: 9.1.1
+      readable-stream: 2.3.7
+      safe-buffer: 5.2.1
+      sqlstring: 2.3.3
+
+  '@vlasky/zongji@0.5.9':
+    dependencies:
+      '@vlasky/mysql': 2.18.7
+      big-integer: 1.6.51
+      iconv-lite: 0.6.3
 
   '@volar/language-core@2.4.23':
     dependencies:
@@ -6052,7 +6086,7 @@ snapshots:
 
   '@volar/source-map@2.4.23': {}
 
-  '@vue-macros/common@3.1.1(vue@3.5.26(typescript@5.8.3))':
+  '@vue-macros/common@3.1.1(vue@3.5.27(typescript@5.8.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.24
       ast-kit: 2.1.3
@@ -6060,7 +6094,7 @@ snapshots:
       magic-string-ast: 1.0.3
       unplugin-utils: 0.3.1
     optionalDependencies:
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
 
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
 
@@ -6099,10 +6133,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.5.26':
+  '@vue/compiler-core@3.5.27':
     dependencies:
       '@babel/parser': 7.28.5
-      '@vue/shared': 3.5.26
+      '@vue/shared': 3.5.27
       entities: 7.0.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -6112,10 +6146,10 @@ snapshots:
       '@vue/compiler-core': 3.5.24
       '@vue/shared': 3.5.24
 
-  '@vue/compiler-dom@3.5.26':
+  '@vue/compiler-dom@3.5.27':
     dependencies:
-      '@vue/compiler-core': 3.5.26
-      '@vue/shared': 3.5.26
+      '@vue/compiler-core': 3.5.27
+      '@vue/shared': 3.5.27
 
   '@vue/compiler-sfc@3.5.24':
     dependencies:
@@ -6129,13 +6163,13 @@ snapshots:
       postcss: 8.5.6
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.5.26':
+  '@vue/compiler-sfc@3.5.27':
     dependencies:
       '@babel/parser': 7.28.5
-      '@vue/compiler-core': 3.5.26
-      '@vue/compiler-dom': 3.5.26
-      '@vue/compiler-ssr': 3.5.26
-      '@vue/shared': 3.5.26
+      '@vue/compiler-core': 3.5.27
+      '@vue/compiler-dom': 3.5.27
+      '@vue/compiler-ssr': 3.5.27
+      '@vue/shared': 3.5.27
       estree-walker: 2.0.2
       magic-string: 0.30.21
       postcss: 8.5.6
@@ -6146,14 +6180,14 @@ snapshots:
       '@vue/compiler-dom': 3.5.24
       '@vue/shared': 3.5.24
 
-  '@vue/compiler-ssr@3.5.26':
+  '@vue/compiler-ssr@3.5.27':
     dependencies:
-      '@vue/compiler-dom': 3.5.26
-      '@vue/shared': 3.5.26
+      '@vue/compiler-dom': 3.5.27
+      '@vue/shared': 3.5.27
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@7.7.7(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.26(typescript@5.8.3))':
+  '@vue/devtools-core@7.7.7(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.27(typescript@5.8.3))':
     dependencies:
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
@@ -6161,7 +6195,7 @@ snapshots:
       nanoid: 5.1.6
       pathe: 2.0.3
       vite-hot-client: 2.1.0(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
     transitivePeerDependencies:
       - vite
 
@@ -6191,49 +6225,49 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@vue/reactivity@3.5.26':
+  '@vue/reactivity@3.5.27':
     dependencies:
-      '@vue/shared': 3.5.26
+      '@vue/shared': 3.5.27
 
-  '@vue/runtime-core@3.5.26':
+  '@vue/runtime-core@3.5.27':
     dependencies:
-      '@vue/reactivity': 3.5.26
-      '@vue/shared': 3.5.26
+      '@vue/reactivity': 3.5.27
+      '@vue/shared': 3.5.27
 
-  '@vue/runtime-dom@3.5.26':
+  '@vue/runtime-dom@3.5.27':
     dependencies:
-      '@vue/reactivity': 3.5.26
-      '@vue/runtime-core': 3.5.26
-      '@vue/shared': 3.5.26
+      '@vue/reactivity': 3.5.27
+      '@vue/runtime-core': 3.5.27
+      '@vue/shared': 3.5.27
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.26(vue@3.5.26(typescript@5.8.3))':
+  '@vue/server-renderer@3.5.27(vue@3.5.27(typescript@5.8.3))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.26
-      '@vue/shared': 3.5.26
-      vue: 3.5.26(typescript@5.8.3)
+      '@vue/compiler-ssr': 3.5.27
+      '@vue/shared': 3.5.27
+      vue: 3.5.27(typescript@5.8.3)
 
   '@vue/shared@3.5.22': {}
 
   '@vue/shared@3.5.24': {}
 
-  '@vue/shared@3.5.26': {}
+  '@vue/shared@3.5.27': {}
 
   '@vueuse/core@12.8.2(typescript@5.8.3)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
       '@vueuse/shared': 12.8.2(typescript@5.8.3)
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/core@14.0.0(vue@3.5.26(typescript@5.8.3))':
+  '@vueuse/core@14.0.0(vue@3.5.27(typescript@5.8.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.0.0
-      '@vueuse/shared': 14.0.0(vue@3.5.26(typescript@5.8.3))
-      vue: 3.5.26(typescript@5.8.3)
+      '@vueuse/shared': 14.0.0(vue@3.5.27(typescript@5.8.3))
+      vue: 3.5.27(typescript@5.8.3)
 
   '@vueuse/metadata@12.8.2': {}
 
@@ -6241,13 +6275,13 @@ snapshots:
 
   '@vueuse/shared@12.8.2(typescript@5.8.3)':
     dependencies:
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/shared@14.0.0(vue@3.5.26(typescript@5.8.3))':
+  '@vueuse/shared@14.0.0(vue@3.5.27(typescript@5.8.3))':
     dependencies:
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
 
   abbrev@3.0.1: {}
 
@@ -6363,6 +6397,10 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.8.23: {}
+
+  big-integer@1.6.51: {}
+
+  bignumber.js@9.1.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -7662,9 +7700,9 @@ snapshots:
 
   lru.min@1.1.2: {}
 
-  lucide-vue-next@0.552.0(vue@3.5.26(typescript@5.8.3)):
+  lucide-vue-next@0.552.0(vue@3.5.27(typescript@5.8.3)):
     dependencies:
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
 
   magic-regexp@0.10.0:
     dependencies:
@@ -7763,7 +7801,7 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
-  mkdist@2.4.1(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3)):
+  mkdist@2.4.1(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3)):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.6)
       citty: 0.1.6
@@ -7780,7 +7818,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       typescript: 5.8.3
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
 
   mlly@1.8.0:
     dependencies:
@@ -7987,17 +8025,17 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.26)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1):
+  nuxt@3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.27)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1):
     dependencies:
       '@dxup/nuxt': 0.1.1(magicast@0.5.1)
       '@nuxt/cli': 3.29.3(magicast@0.5.1)
-      '@nuxt/devtools': 2.7.0(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.26(typescript@5.8.3))
+      '@nuxt/devtools': 2.7.0(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.27(typescript@5.8.3))
       '@nuxt/kit': 3.20.0(magicast@0.5.1)
-      '@nuxt/nitro-server': 3.20.0(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(nuxt@3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.26)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(typescript@5.8.3)
+      '@nuxt/nitro-server': 3.20.0(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(nuxt@3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.27)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(typescript@5.8.3)
       '@nuxt/schema': 3.20.0
       '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
-      '@nuxt/vite-builder': 3.20.0(@types/node@20.19.8)(magicast@0.5.1)(nuxt@3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.26)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3))(yaml@2.8.1)
-      '@unhead/vue': 2.0.19(vue@3.5.26(typescript@5.8.3))
+      '@nuxt/vite-builder': 3.20.0(@types/node@20.19.8)(magicast@0.5.1)(nuxt@3.20.0(@parcel/watcher@2.5.1)(@types/node@20.19.8)(@vue/compiler-sfc@3.5.27)(db0@0.3.4(mysql2@3.14.2))(encoding@0.1.13)(ioredis@5.8.2)(magicast@0.5.1)(mysql2@3.14.2)(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1))(rollup@4.52.5)(terser@5.44.0)(tsx@4.20.6)(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3))(yaml@2.8.1)
+      '@unhead/vue': 2.0.19(vue@3.5.27(typescript@5.8.3))
       '@vue/shared': 3.5.22
       c12: 3.3.1(magicast@0.5.1)
       chokidar: 4.0.3
@@ -8042,10 +8080,10 @@ snapshots:
       unctx: 2.4.1
       unimport: 5.5.0
       unplugin: 2.3.10
-      unplugin-vue-router: 0.16.1(@vue/compiler-sfc@3.5.26)(typescript@5.8.3)(vue-router@4.6.3(vue@3.5.26(typescript@5.8.3)))(vue@3.5.26(typescript@5.8.3))
+      unplugin-vue-router: 0.16.1(@vue/compiler-sfc@3.5.27)(typescript@5.8.3)(vue-router@4.6.3(vue@3.5.27(typescript@5.8.3)))(vue@3.5.27(typescript@5.8.3))
       untyped: 2.0.0
-      vue: 3.5.26(typescript@5.8.3)
-      vue-router: 4.6.3(vue@3.5.26(typescript@5.8.3))
+      vue: 3.5.27(typescript@5.8.3)
+      vue-router: 4.6.3(vue@3.5.27(typescript@5.8.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
       '@types/node': 20.19.8
@@ -8582,6 +8620,16 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
+  readable-stream@2.3.7:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@2.3.8:
     dependencies:
       core-util-is: 1.0.3
@@ -8624,19 +8672,19 @@ snapshots:
 
   regexp-tree@0.1.27: {}
 
-  reka-ui@2.6.0(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3)):
+  reka-ui@2.6.0(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3)):
     dependencies:
       '@floating-ui/dom': 1.7.4
-      '@floating-ui/vue': 1.1.9(vue@3.5.26(typescript@5.8.3))
+      '@floating-ui/vue': 1.1.9(vue@3.5.27(typescript@5.8.3))
       '@internationalized/date': 3.10.0
       '@internationalized/number': 3.6.5
-      '@tanstack/vue-virtual': 3.13.12(vue@3.5.26(typescript@5.8.3))
+      '@tanstack/vue-virtual': 3.13.12(vue@3.5.27(typescript@5.8.3))
       '@vueuse/core': 12.8.2(typescript@5.8.3)
       '@vueuse/shared': 12.8.2(typescript@5.8.3)
       aria-hidden: 1.2.6
       defu: 6.1.4
       ohash: 2.0.11
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
@@ -9202,7 +9250,7 @@ snapshots:
 
   ultrahtml@1.6.0: {}
 
-  unbuild@3.6.1(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3)):
+  unbuild@3.6.1(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3)):
     dependencies:
       '@rollup/plugin-alias': 5.1.1(rollup@4.52.5)
       '@rollup/plugin-commonjs': 28.0.9(rollup@4.52.5)
@@ -9218,7 +9266,7 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.6.1
       magic-string: 0.30.21
-      mkdist: 2.4.1(typescript@5.8.3)(vue@3.5.26(typescript@5.8.3))
+      mkdist: 2.4.1(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -9292,11 +9340,11 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.3
 
-  unplugin-vue-router@0.16.1(@vue/compiler-sfc@3.5.26)(typescript@5.8.3)(vue-router@4.6.3(vue@3.5.26(typescript@5.8.3)))(vue@3.5.26(typescript@5.8.3)):
+  unplugin-vue-router@0.16.1(@vue/compiler-sfc@3.5.27)(typescript@5.8.3)(vue-router@4.6.3(vue@3.5.27(typescript@5.8.3)))(vue@3.5.27(typescript@5.8.3)):
     dependencies:
       '@babel/generator': 7.28.5
-      '@vue-macros/common': 3.1.1(vue@3.5.26(typescript@5.8.3))
-      '@vue/compiler-sfc': 3.5.26
+      '@vue-macros/common': 3.1.1(vue@3.5.27(typescript@5.8.3))
+      '@vue/compiler-sfc': 3.5.27
       '@vue/language-core': 3.1.2(typescript@5.8.3)
       ast-walker-scope: 0.8.3
       chokidar: 4.0.3
@@ -9313,7 +9361,7 @@ snapshots:
       unplugin-utils: 0.3.1
       yaml: 2.8.1
     optionalDependencies:
-      vue-router: 4.6.3(vue@3.5.26(typescript@5.8.3))
+      vue-router: 4.6.3(vue@3.5.27(typescript@5.8.3))
     transitivePeerDependencies:
       - typescript
       - vue
@@ -9442,7 +9490,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.0.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.26(typescript@5.8.3)):
+  vite-plugin-vue-tracer@1.0.1(vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.27(typescript@5.8.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.7
@@ -9450,7 +9498,7 @@ snapshots:
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: 7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
 
   vite@7.1.12(@types/node@20.19.8)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
@@ -9474,24 +9522,24 @@ snapshots:
     dependencies:
       ufo: 1.6.1
 
-  vue-demi@0.14.10(vue@3.5.26(typescript@5.8.3)):
+  vue-demi@0.14.10(vue@3.5.27(typescript@5.8.3)):
     dependencies:
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
 
   vue-devtools-stub@0.1.0: {}
 
-  vue-router@4.6.3(vue@3.5.26(typescript@5.8.3)):
+  vue-router@4.6.3(vue@3.5.27(typescript@5.8.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.27(typescript@5.8.3)
 
-  vue@3.5.26(typescript@5.8.3):
+  vue@3.5.27(typescript@5.8.3):
     dependencies:
-      '@vue/compiler-dom': 3.5.26
-      '@vue/compiler-sfc': 3.5.26
-      '@vue/runtime-dom': 3.5.26
-      '@vue/server-renderer': 3.5.26(vue@3.5.26(typescript@5.8.3))
-      '@vue/shared': 3.5.26
+      '@vue/compiler-dom': 3.5.27
+      '@vue/compiler-sfc': 3.5.27
+      '@vue/runtime-dom': 3.5.27
+      '@vue/server-renderer': 3.5.27(vue@3.5.27(typescript@5.8.3))
+      '@vue/shared': 3.5.27
     optionalDependencies:
       typescript: 5.8.3
 


### PR DESCRIPTION
…cation

- Added @vlasky/zongji dependency for MySQL binlog parsing
- Created CDCService with INSERT/UPDATE/DELETE event handling
- Implemented binlog position tracking for resume capability
- Added auto-reconnect logic with configurable retry attempts
- Added CDC configuration options (enabled, autoStart, reconnect settings)
- Added REST endpoints for CDC status, start, stop, and reset-stats
- Implemented multi-database CDC instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time Change Data Capture (CDC) streaming MySQL changes into DuckDB.
  * REST endpoints to view CDC status, start, stop, and reset CDC statistics.
  * CDC configuration options: enable, auto-start, reconnect attempts/delay, and SSL handling.
  * Graceful shutdown: CDC services stopped before server exit.

* **Documentation**
  * Added guidance comparing DuckDB vs ColumnStore and ClickHouse for MySQL replication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->